### PR TITLE
⬆️ Improve Debug Notification @ glance

### DIFF
--- a/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
@@ -38,7 +38,7 @@ object DebugHelper {
         postNotification(
                 ctx,
                 threadIdentifier,
-                "${ThumbnailGenerator.mapResultToEmoji(result)} $currentTime",
+                "${ThumbnailGenerator.workEmoji} $currentTime",
                 """
                     • Result: ${ThumbnailGenerator.mapResultToEmoji(result)} ${result.javaClass.simpleName}
                     • dartTask: $dartTask

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
@@ -38,12 +38,11 @@ object DebugHelper {
         postNotification(
                 ctx,
                 threadIdentifier,
-                "${ThumbnailGenerator.workEmoji} $currentTime",
+                "${ThumbnailGenerator.mapResultToEmoji(result)} $currentTime",
                 """
-                    Perform fetch completed:
+                    • Result: ${ThumbnailGenerator.mapResultToEmoji(result)} ${result.javaClass.simpleName}
                     • dartTask: $dartTask
                     • Elapsed time: ${mapMillisToSeconds(fetchDuration)}
-                    • Result: ${ThumbnailGenerator.mapResultToEmoji(result)} ${result.javaClass.simpleName}
                 """.trimIndent()
         )
     }
@@ -58,7 +57,6 @@ object DebugHelper {
                 threadIdentifier,
                 "${ThumbnailGenerator.workEmoji} $currentTime",
                 """
-                Starting Dart/Flutter with following params:
                 • dartTask: $dartTask
                 • callbackHandle: $callbackHandle 
                 • callBackName: ${callbackInfo?.callbackName ?: "not found"}


### PR DESCRIPTION
It was difficult to get the status of a task when notification were in the collapsed state because the status was on the last line.
Switched the status around