### PR TITLE
✅ Bugfix/fix ios background fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.3
+
+* iOS & Android:
+  * Result of `BackgroundTaskHandler` now correctly returns to background method channel
+* iOS:
+  * Invoking `iOSPerformFetch` method now no longer crashes
+  * The iOS example app now  implements `setPluginRegistrantCallback` as described in our docs, making it possible to access other plugins during a backround fetch
+  * Dart debug logging is now visible again in Xcode's console
+  
 # 0.1.2
 
 * Android:
@@ -88,7 +97,7 @@
   * Fixes [#6](https://github.com/vrtdev/flutter_workmanager/issues/6)
   * Fixes [#4](https://github.com/vrtdev/flutter_workmanager/issues/4)
   * [‼️ BREAKING change] A user should extend a custom `Application` and register it in its `AndroidManifest.xml`
- 
+
     ```kotlin
     class App : FlutterApplication(), PluginRegistry.PluginRegistrantCallback {
         override fun onCreate() {
@@ -101,7 +110,7 @@
         }
     }
     ```
-      
+    
     ```xml
     <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -138,7 +147,7 @@
             </activity>
         </application>
     </manifest>
-    ```  
+    ```
     
 # 0.0.6+1
 
@@ -183,4 +192,4 @@
     * requires device idle
     * requires storage not low
   * back off policy
- 
+

--- a/IOS_SETUP.md
+++ b/IOS_SETUP.md
@@ -1,5 +1,9 @@
 # iOS Installation
 
+## Prerequisites
+
+This plugin is compatible with Swift 4.2 and higher. Make sure you are using Xcode 10.3 or higher.
+
 ## Enabling Background Fetch
 
 Background fetching is very different compared to Android's Background Jobs.  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is especially useful to run periodic tasks, such as fetching remote data on
 
 ```yaml
 dependencies:
-  workmanager: ^0.1.2
+  workmanager: ^0.1.3
 ```
 ```shell script
 flutter pub get

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/workmanager/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   path_provider: f96fff6166a8867510d2c25fdcc346327cc4b259
   workmanager: ffff78bf18495e2bc5b8c955ead94a81db340681
 
 PODFILE CHECKSUM: 57268ad4ad4314d2e0bdf5c907ae01d8abcc9294
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = 79BMQESM94;
-						LastSwiftMigration = 0910;
+						LastSwiftMigration = 1110;
 					};
 				};
 			};
@@ -390,6 +390,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -527,6 +528,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -554,6 +556,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -176,7 +175,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -211,7 +210,6 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Profile"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -11,6 +11,12 @@ import workmanager
         GeneratedPluginRegistrant.register(with: self)
         UNUserNotificationCenter.current().delegate = self
         
+        WorkmanagerPlugin.setPluginRegistrantCallback { registry in
+            // registry in this case is the FlutterEngine that is created in Workmanager's performFetchWithCompletionHandler
+            // This will make other plugins available during a background fetch
+            GeneratedPluginRegistrant.register(with: registry)
+        }
+        
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
         
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
@@ -17,23 +16,27 @@ void callbackDispatcher() {
   Workmanager.executeTask((task, inputData) async {
     switch (task) {
       case simpleTaskKey:
-        developer.log("$simpleTaskKey was executed. inputData = $inputData");
+        print("$simpleTaskKey was executed. inputData = $inputData");
         Directory tempDir = await getTemporaryDirectory();
         String tempPath = tempDir.path;
-        developer
-            .log("You can access other plugins in the background: $tempPath");
+        print(
+            "You can access other plugins in the background, for example Directory.getTemporaryDirectory(): $tempPath");
         break;
       case simpleDelayedTask:
-        developer.log("$simpleDelayedTask was executed");
+        print("$simpleDelayedTask was executed");
         break;
       case simplePeriodicTask:
-        developer.log("$simplePeriodicTask was executed");
+        print("$simplePeriodicTask was executed");
         break;
       case simplePeriodic1HourTask:
-        developer.log("$simplePeriodic1HourTask was executed");
+        print("$simplePeriodic1HourTask was executed");
         break;
       case Workmanager.iOSBackgroundTask:
-        developer.log("The iOS background fetch was triggered");
+        print("The iOS background fetch was triggered");
+        Directory tempDir = await getTemporaryDirectory();
+        String tempPath = tempDir.path;
+        print(
+            "You can access other plugins in the background, for example Directory.getTemporaryDirectory(): $tempPath");
         break;
     }
 
@@ -153,7 +156,7 @@ class _MyAppState extends State<MyApp> {
                 child: Text("Cancel All"),
                 onPressed: () async {
                   await Workmanager.cancelAll();
-                  developer.log('Cancel all tasks completed');
+                  print('Cancel all tasks completed');
                 },
               ),
             ],

--- a/lib/src/workmanager.dart
+++ b/lib/src/workmanager.dart
@@ -77,7 +77,7 @@ class Workmanager {
     WidgetsFlutterBinding.ensureInitialized();
     _backgroundChannel.setMethodCallHandler((call) async {
       final payload = call.arguments["be.tramckrijte.workmanager.PAYLOAD"];
-      backgroundTask(
+      return backgroundTask(
         call.arguments["be.tramckrijte.workmanager.DART_TASK"],
         payload == null ? null : jsonDecode(payload),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.1.2
+version: 0.1.3
 authors:
   - Tim Rijckaert <tim.rijckaert@gmail.com>
   - Jeremie Vincke <jeremie@movify.com>


### PR DESCRIPTION
* iOS & Android:
  * Result of `BackgroundTaskHandler` now correctly returns to background method channel
* iOS:
  * Invoking `iOSPerformFetch` method now no longer crashes
  * The iOS example app now  implements `setPluginRegistrantCallback` as described in our docs, making it possible to access other plugins during a backround fetch
  * Dart debug logging is now visible again in Xcode's console

Fixes issue #89