### PR TITLE
📝 Update Bug reporting Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,5 +11,12 @@ assignees: ''
 - [x] I have read the [README](https://github.com/vrtdev/flutter_workmanager/blob/master/README.md)
 - [x] I have done the setup for [Android](https://github.com/vrtdev/flutter_workmanager/blob/master/ANDROID_SETUP.md)
 - [x] I have done the setup for [iOS](https://github.com/vrtdev/flutter_workmanager/blob/master/IOS_SETUP.md)
+- [x] I have ran the sample app and it does not work there
+
+**Flutter Workmanager Version**
 
 **Describe the error**
+Describe error
+Optionally provide the least amount of code that shows this behaviour. Ideally in the `sample` app.
+
+**Output of `flutter doctor -v`**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,15 +14,16 @@ assignees: ''
 - [x] I have ran the sample app and it does not work there
 
 **Version**
-| Technology          | Version       |
-| ------------------- | ------------- |
-| Workmanager version |               |
-| XCode version       |               |
-| Swift version       |               |
+
+| Technology           | Version       |
+| -------------------  | ------------- |
+| Workmanager version  |               |
+| Xcode version        |               |
+| Swift version        |               |
+| iOS deployment target|               |
 
 **Describe the error**
 Describe error
 Optionally provide the least amount of code that shows this behaviour. Ideally in the `sample` app.
 
 **Output of `flutter doctor -v`**
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,12 +20,6 @@ assignees: ''
 | XCode version       |               |
 | Swift version       |               |
 
-Test
-| First Header | Second Header |
-| ------------- | ------------- |
-| Content Cell  | Content Cell  |
-| Content Cell  | Content Cell  |
-
 **Describe the error**
 Describe error
 Optionally provide the least amount of code that shows this behaviour. Ideally in the `sample` app.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: You have run through the README.md for both Android and iOS and it still won't
+  work
+title: "\U0001F41E[Enter Bug Description]"
+labels: bug
+assignees: ''
+
+---
+
+- [x] I have read the [README](https://github.com/vrtdev/flutter_workmanager/blob/master/README.md)
+- [x] I have done the setup for [Android](https://github.com/vrtdev/flutter_workmanager/blob/master/ANDROID_SETUP.md)
+- [x] I have done the setup for [iOS](https://github.com/vrtdev/flutter_workmanager/blob/master/IOS_SETUP.md)
+
+**Describe the error**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,16 @@ assignees: ''
 - [x] I have done the setup for [iOS](https://github.com/vrtdev/flutter_workmanager/blob/master/IOS_SETUP.md)
 - [x] I have ran the sample app and it does not work there
 
-**Flutter Workmanager Version**
+**Version**
+Technology | Version
+------------ | -------------
+Workmanager version | 
+XCode version | 
+Swift version |
 
 **Describe the error**
 Describe error
 Optionally provide the least amount of code that shows this behaviour. Ideally in the `sample` app.
 
 **Output of `flutter doctor -v`**
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,14 +14,14 @@ assignees: ''
 - [x] I have ran the sample app and it does not work there
 
 **Version**
-| Technology | Version |
+| Technology          | Version       |
 | ------------------- | ------------- |
-| Workmanager version | |
-| XCode version       | |
-| Swift version       | |
+| Workmanager version |               |
+| XCode version       |               |
+| Swift version       |               |
 
 Test
-| First Header  | Second Header |
+| First Header | Second Header |
 | ------------- | ------------- |
 | Content Cell  | Content Cell  |
 | Content Cell  | Content Cell  |

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,11 +14,11 @@ assignees: ''
 - [x] I have ran the sample app and it does not work there
 
 **Version**
-Technology | Version
------------- | -------------
-Workmanager version | 
-XCode version | 
-Swift version |
+| Technology | Version |
+| ------------------- | ------------- |
+| Workmanager version | |
+| XCode version       | |
+| Swift version       | |
 
 **Describe the error**
 Describe error

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,12 @@ assignees: ''
 | XCode version       | |
 | Swift version       | |
 
+Test
+| First Header  | Second Header |
+| ------------- | ------------- |
+| Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  |
+
 **Describe the error**
 Describe error
 Optionally provide the least amount of code that shows this behaviour. Ideally in the `sample` app.


### PR DESCRIPTION
I see a lot of _issues_ which are not issues, but rather people how can't seem to take the time to read through our wonderful documentation.

When opening up a new issue they will be represented with the links again.
As well as gathering some interesting information about which versions the user is using