### PR TITLE
⬆️ Pubspec 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
 dev_dependencies:
   dep_check: 0.0.2
   test: ^1.9.2
+  test_api:
+  matcher:
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
- Error when uploading 0.1.4

> Your pubspec.yaml must not override non-dev dependencies.
> This ensures you test your package against the same versions of its dependencies that users will have when they use it.
> Sorry, your package is missing a requirement and can't be published yet.

Set `dev_dependencies` explicitly