### PR TITLE
Cleanup FlutterEngine when the job is stopped or canceled.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,4 +44,5 @@ dependencies {
 
     def work_version = "2.2.0"
     implementation "androidx.work:work-runtime:$work_version"
+    implementation "androidx.concurrent:concurrent-futures:1.0.0"
 }

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/BackgroundWorker.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/BackgroundWorker.kt
@@ -3,8 +3,10 @@ package be.tramckrijte.workmanager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import androidx.work.Worker
+import androidx.concurrent.futures.ResolvableFuture
+import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
+import com.google.common.util.concurrent.ListenableFuture
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry
@@ -14,8 +16,6 @@ import io.flutter.view.FlutterCallbackInformation
 import io.flutter.view.FlutterMain
 import io.flutter.view.FlutterRunArguments
 import java.util.*
-import java.util.concurrent.CountDownLatch
-import kotlin.system.measureTimeMillis
 
 /***
  * A simple worker that will post your input back to your Flutter application.
@@ -24,7 +24,7 @@ import kotlin.system.measureTimeMillis
  *
  */
 class BackgroundWorker(private val ctx: Context,
-                       private val workerParams: WorkerParameters) : Worker(ctx, workerParams), MethodChannel.MethodCallHandler {
+                       private val workerParams: WorkerParameters) : ListenableWorker(ctx, workerParams), MethodChannel.MethodCallHandler {
 
     private lateinit var backgroundChannel: MethodChannel
 
@@ -46,46 +46,57 @@ class BackgroundWorker(private val ctx: Context,
     private val isInDebug
         get() = workerParams.inputData.getBoolean(IS_IN_DEBUG_MODE_KEY, false)
 
-    private val latch = CountDownLatch(1)
     private val randomThreadIdentifier = Random().nextInt()
-    var result: Result = Result.retry()
     private lateinit var engine: FlutterEngine
 
-    override fun doWork(): Result {
-        Handler(Looper.getMainLooper()).apply {
-            post {
-                engine = FlutterEngine(ctx)
-                FlutterMain.ensureInitializationComplete(ctx, null)
+    private var startTime: Long = 0
+    private val resolvableFuture = ResolvableFuture.create<Result>()
 
-                val callbackHandle = SharedPreferenceHelper.getCallbackHandle(ctx)
-                val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
-                val dartBundlePath = FlutterMain.findAppBundlePath()
+    override fun startWork(): ListenableFuture<Result> {
+        startTime = System.currentTimeMillis()
 
-                if (isInDebug) {
-                    DebugHelper.postTaskStarting(ctx, randomThreadIdentifier, dartTask, payload, callbackHandle, callbackInfo, dartBundlePath)
-                }
+        engine = FlutterEngine(ctx)
+        FlutterMain.ensureInitializationComplete(ctx, null)
 
-                //Backwards compatibility with v1. We register all the user's plugins.
-                WorkmanagerPlugin.pluginRegistryCallback?.registerWith(ShimPluginRegistry(engine))
-                engine.dartExecutor.executeDartCallback(DartExecutor.DartCallback(ctx.assets, dartBundlePath, callbackInfo))
+        val callbackHandle = SharedPreferenceHelper.getCallbackHandle(ctx)
+        val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+        val dartBundlePath = FlutterMain.findAppBundlePath()
 
-                backgroundChannel = MethodChannel(engine.dartExecutor, BACKGROUND_CHANNEL_NAME)
-                backgroundChannel.setMethodCallHandler(this@BackgroundWorker)
-            }
-
-            val fetchDuration = measureTimeMillis {
-                latch.await()
-            }
-
-            if (isInDebug) {
-                DebugHelper.postTaskCompleteNotification(ctx, randomThreadIdentifier, dartTask, payload, fetchDuration, result)
-            }
-
-            post {
-                engine.destroy()
-            }
+        if (isInDebug) {
+            DebugHelper.postTaskStarting(ctx, randomThreadIdentifier, dartTask, payload, callbackHandle, callbackInfo, dartBundlePath)
         }
-        return result
+
+        //Backwards compatibility with v1. We register all the user's plugins.
+        WorkmanagerPlugin.pluginRegistryCallback?.registerWith(ShimPluginRegistry(engine))
+        engine.dartExecutor.executeDartCallback(DartExecutor.DartCallback(ctx.assets, dartBundlePath, callbackInfo))
+
+        backgroundChannel = MethodChannel(engine.dartExecutor, BACKGROUND_CHANNEL_NAME)
+        backgroundChannel.setMethodCallHandler(this@BackgroundWorker)
+
+        return resolvableFuture
+    }
+
+    override fun onStopped() {
+       stopEngine(null)
+    }
+
+    private fun stopEngine(result: Result?) {
+        val fetchDuration = System.currentTimeMillis() - startTime
+
+        if (isInDebug) {
+            DebugHelper.postTaskCompleteNotification(ctx, randomThreadIdentifier, dartTask, payload, fetchDuration, result ?: Result.failure())
+        }
+
+        // No result indicates we were signalled to stop by WorkManager.  The result is already
+        // STOPPED, so no need to resolve another one.
+        if (result != null) {
+            resolvableFuture.set(result)
+        }
+
+        // If stopEngine is called from `onStopped`, it may not be from the main thread.
+        Handler(Looper.getMainLooper()).post {
+            engine.destroy()
+        }
     }
 
     override fun onMethodCall(call: MethodCall, r: MethodChannel.Result) {
@@ -96,17 +107,16 @@ class BackgroundWorker(private val ctx: Context,
                         mapOf(DART_TASK_KEY to dartTask, PAYLOAD_KEY to payload),
                         object : MethodChannel.Result {
                             override fun notImplemented() {
-                                latch.countDown()
+                                stopEngine(Result.failure())
                             }
 
                             override fun error(p0: String?, p1: String?, p2: Any?) {
-                                latch.countDown()
+                                stopEngine(Result.failure())
                             }
 
                             override fun success(receivedResult: Any?) {
                                 val wasSuccessFul = receivedResult?.let { it as Boolean? } == true
-                                result = if (wasSuccessFul) Result.success() else Result.retry()
-                                latch.countDown()
+                                stopEngine(if (wasSuccessFul) Result.success() else Result.retry())
                             }
                         })
         }


### PR DESCRIPTION
This PR aims to improve the Android implementation, by cleaning up the FlutterEngine when a job has been stopped or canceled.  This involves two primary changes:

1. Utilize ListenableWorker, instead of Worker.
2. Implement onStopped to cleanup FlutterEngine

Worker is based on a simple-work principle.  The work should be performed, and then synchronously returned when completed.  Additionally, Worker executes the work on a background thread for you.  The two problems with this are:
1. FlutterEngine expects to be created, operated with, on the MainThread.
2. The work is asynchronous, requiring a CountdownLatch to block for it to finish.
The previous implementation solves these problems by moving from the MainThread -> BackgroundThread -> MainThread with the help of Handler & Looper.  Additionally, the CountdownLatch is utilized to block for the result.

However, by utilizing the ListenableWorker (which Worker is an extension of), we can do away with both problems.  ListenableWorker does not enforce a synchronous return pattern for you, rather lets you return a Future that then completes whenever the asynchronous work has completed.  This fits quite nicely with the real mechanism involving FlutterEngine background work, and does away with the previously mentioned two elements.

Now, the FlutterEngine is created without context switching, and the method completes immediately with a ResolvableFuture, which will be resolved upon existing MethodChannel interactions.

Finally, for the motivation these changes - to support canceling the work when the job is stopped or canceled.  In my tests, I was finding that occasionally, the FlutterEngine would hang while doing work.  The job only was getting 10 minutes to finish.  When 10 minutes were up and the FlutterEngine had not finished it's work, it would be canceled.  Unfortunately, the FlutterEngine still would float in this case, continuing to "do nothing" but waste CPU cycles and hold onto some memory.  This would compound more and more, every time an engine would be created, and not destroyed.

Now, onStopped is implemented, destroying the FlutterEngine.